### PR TITLE
Add missing webhook event: task.move.project

### DIFF
--- a/app/Subscriber/NotificationSubscriber.php
+++ b/app/Subscriber/NotificationSubscriber.php
@@ -21,6 +21,7 @@ class NotificationSubscriber extends BaseSubscriber implements EventSubscriberIn
             TaskModel::EVENT_CLOSE             => 'handleEvent',
             TaskModel::EVENT_OPEN              => 'handleEvent',
             TaskModel::EVENT_MOVE_COLUMN       => 'handleEvent',
+            TaskModel::EVENT_MOVE_PROJECT      => 'handleEvent',
             TaskModel::EVENT_MOVE_POSITION     => 'handleEvent',
             TaskModel::EVENT_MOVE_SWIMLANE     => 'handleEvent',
             TaskModel::EVENT_ASSIGNEE_CHANGE   => 'handleEvent',


### PR DESCRIPTION
Fixes #3969

[] I read the [contributor guidelines](https://docs.kanboard.org/en/latest/developer_guide/contributing.html#i-want-to-contribute-to-the-code)
